### PR TITLE
task-31-init-project

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,4 @@
+loglevel=warn
+progress=false
+package-lock=false
+save-exact=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,42 +1,43 @@
-version: "3.9"
+version: '3.9'
 
 services:
-    client:
-        container_name: prakticum-client
-        image: prakticum-client
-        build:
-            context: .
-            dockerfile: Dockerfile.client
-            args:
-              CLIENT_PORT: ${CLIENT_PORT}
-        restart: always
-        ports:
-            - "${CLIENT_PORT}:80"
-        environment:
-          - CLIENT_PORT=${CLIENT_PORT}
-          - SERVER_PORT=${SERVER_PORT}
-    server:
-        container_name: prakticum-server
-        image: prackicum-server
-        build:
-            context: .
-            dockerfile: Dockerfile.server
-            args:
-              SERVER_PORT: ${SERVER_PORT}
-        restart: always
-        ports:
-            - "${SERVER_PORT}:${SERVER_PORT}"
-        environment:
-          SERVER_PORT: ${SERVER_PORT}
+  postgres:
+    container_name: postgresql
+    image: postgres:14
+    restart: always
+    ports:
+      - '${POSTGRES_PORT}:${POSTGRES_PORT}'
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - ./tmp/pgdata:/var/lib/postgresql/data
 
-    postgres:
-      image: postgres:14     
-      ports:
-        - "${POSTGRES_PORT}:${POSTGRES_PORT}"
-      environment:
-        POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-        POSTGRES_USER: ${POSTGRES_USER}
-        POSTGRES_DB: ${POSTGRES_DB}
-      volumes:
-        - ./tmp/pgdata:/var/lib/postgresql/data
-
+  client:
+    container_name: prakticum-client
+    image: prakticum-client
+    build:
+      context: .
+      dockerfile: Dockerfile.client
+      args:
+        CLIENT_PORT: ${CLIENT_PORT}
+    restart: always
+    ports:
+      - '${CLIENT_PORT}:80'
+    environment:
+      - CLIENT_PORT=${CLIENT_PORT}
+      - SERVER_PORT=${SERVER_PORT}
+  server:
+    container_name: prakticum-server
+    image: prackicum-server
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+      args:
+        SERVER_PORT: ${SERVER_PORT}
+    restart: always
+    ports:
+      - '${SERVER_PORT}:${SERVER_PORT}'
+    environment:
+      SERVER_PORT: ${SERVER_PORT}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "bootstrap": "yarn && node init.js && lerna clean && yarn && lerna bootstrap",
     "build": "lerna run build",
-    "dev:client": "lerna run dev  --scope=client",
+    "dev:client": "lerna run dev --scope=client",
     "dev:server": "lerna run dev --scope=server",
     "dev": "lerna run dev",
     "test": "lerna run test",
@@ -20,7 +20,7 @@
     "node": ">=15"
   },
   "devDependencies": {
-    "@evilmartians/lefthook": "^1.1.1",
-    "lerna": "^5.4.3"
+    "@evilmartians/lefthook": "1.1.1",
+    "lerna": "5.4.3"
   }
 }

--- a/packages/client/.yarnrc
+++ b/packages/client/.yarnrc
@@ -1,0 +1,4 @@
+loglevel=warn
+progress=false
+package-lock=false
+save-exact=true

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -11,28 +11,28 @@
     "test": "jest ./"
   },
   "dependencies": {
-    "dotenv": "^16.0.2",
-    "eslint-config-prettier": "^8.5.0",
-    "prettier": "^2.7.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "dotenv": "16.0.2",
+    "eslint-config-prettier": "8.5.0",
+    "prettier": "2.7.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "@testing-library/react": "^13.3.0",
-    "@types/jest": "^28.1.8",
-    "@types/react": "^18.0.17",
-    "@types/react-dom": "^18.0.6",
-    "@typescript-eslint/eslint-plugin": "^5.35.1",
-    "@typescript-eslint/parser": "^5.35.1",
-    "@vitejs/plugin-react": "^2.0.1",
-    "eslint": "^8.23.0",
-    "jest": "^28",
-    "jest-environment-jsdom": "^29.0.1",
-    "lefthook": "^1.1.1",
-    "prettier": "^2.7.1",
-    "ts-jest": "^28.0.8",
-    "typescript": "^4.8.2",
-    "vite": "^3.0.7"
+    "@testing-library/react": "13.3.0",
+    "@types/jest": "28.1.8",
+    "@types/react": "18.0.17",
+    "@types/react-dom": "18.0.6",
+    "@typescript-eslint/eslint-plugin": "5.35.1",
+    "@typescript-eslint/parser": "5.35.1",
+    "@vitejs/plugin-react": "2.0.1",
+    "eslint": "8.23.0",
+    "jest": "28",
+    "jest-environment-jsdom": "29.0.1",
+    "lefthook": "1.1.1",
+    "prettier": "2.7.1",
+    "ts-jest": "28.0.8",
+    "typescript": "4.8.2",
+    "vite": "3.0.7"
   },
   "license": "MIT"
 }

--- a/packages/server/.yarnrc
+++ b/packages/server/.yarnrc
@@ -1,0 +1,4 @@
+loglevel=warn
+progress=false
+package-lock=false
+save-exact=true

--- a/packages/server/db.ts
+++ b/packages/server/db.ts
@@ -7,7 +7,7 @@ export const createClientAndConnect = async (): Promise<Client | null> => {
   try {
     const client = new Client({
       user: POSTGRES_USER,
-      host: 'localhost',
+      host: 'postgresql',
       database: POSTGRES_DB,
       password: POSTGRES_PASSWORD,
       port: Number(POSTGRES_PORT),

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,34 +5,34 @@
   "scripts": {
     "build": "tsc --p ./tsconfig.prod.json",
     "preview": "node ./dist/index.js",
-    "dev": "NODE_ENV=development nodemon index.ts",
+    "dev": "nodemon index.ts",
     "lint": "eslint .",
     "format": "prettier --write .",
     "test": "jest ."
   },
   "dependencies": {
-    "cors": "^2.8.5",
-    "dotenv": "^16.0.2",
-    "eslint-config-prettier": "^8.5.0",
-    "express": "^4.18.1",
-    "pg": "^8.8.0",
-    "prettier": "^2.7.1"
+    "cors": "2.8.5",
+    "dotenv": "16.0.2",
+    "eslint-config-prettier": "8.5.0",
+    "express": "4.18.1",
+    "pg": "8.8.0",
+    "prettier": "2.7.1"
   },
   "devDependencies": {
-    "@types/cors": "^2.8.12",
-    "@types/express": "^4.17.13",
-    "@types/jest": "^28.1.8",
-    "@types/pg": "^8.6.5",
-    "@typescript-eslint/eslint-plugin": "^5.35.1",
-    "@typescript-eslint/parser": "^5.35.1",
-    "babel-jest": "^29.0.1",
-    "eslint": "^8.23.0",
-    "jest": "^28",
-    "nodemon": "^2.0.19",
-    "prettier": "^2.7.1",
-    "ts-jest": "^28.0.8",
-    "ts-node": "^10.9.1",
-    "typescript": "^4.8.2"
+    "@types/cors": "2.8.12",
+    "@types/express": "4.17.13",
+    "@types/jest": "28.1.8",
+    "@types/pg": "8.6.5",
+    "@typescript-eslint/eslint-plugin": "5.35.1",
+    "@typescript-eslint/parser": "5.35.1",
+    "babel-jest": "29.0.1",
+    "eslint": "8.23.0",
+    "jest": "28",
+    "nodemon": "2.0.19",
+    "prettier": "2.7.1",
+    "ts-jest": "28.0.8",
+    "ts-node": "10.9.1",
+    "typescript": "4.8.2"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
### Начальный сетап проекта

https://linear.app/teamproject/issue/PRA-31/nachalnyj-setap-proekta

-------------------
1. Создать репозиторий проекта
"Воспользуйтесь уже готовым шаблоном с конфигурацией https://github.com/yandex-praktikum/client-server-template-with-vite"
2. Убедиться что проект запускает и работает
3. Убедиться что линтеры настроены и работают
4. Убедиться что тесты работают
5. Убедиться что статика деплоится в для каждой ветки
-------------------
1. Изменён dev скрипт для запуска server
2. В конфигурации db.ts (подключение сервера к бд) заменён хост на докерский "postgresql", если запуск сервера с локальной машины, нужно вернуть хост "localhost"
3. Зафиксированы версии для всех зависимостей